### PR TITLE
Fix possible string slice length panic

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -17,11 +17,11 @@ impl<'gc> String<'gc> {
         let len = s.len();
         if len <= 8 {
             let mut b = [0; 8];
-            b.copy_from_slice(s);
+            b[..len].copy_from_slice(s);
             String::Short8(len as u8, Gc::allocate(mc, b))
         } else if len <= 32 {
             let mut b = [0; 32];
-            b.copy_from_slice(s);
+            b[..len].copy_from_slice(s);
             String::Short32(len as u8, Gc::allocate(mc, b))
         } else {
             String::Long(Gc::allocate(mc, s.to_vec().into_boxed_slice()))


### PR DESCRIPTION
While actually running the test suites just to see what happens I noticed a panic that occurs due to the `copy_from_slice` function asserting that both slices are of the same length. 