### PR TITLE
add `luster --dump` flag to print the parsed bytecode

### DIFF
--- a/gc-arena/src/gc.rs
+++ b/gc-arena/src/gc.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::NonNull;
@@ -22,6 +22,12 @@ impl<'gc, T: 'gc + Collect + Debug> Debug for Gc<'gc, T> {
         fmt.debug_struct("Gc")
             .field("ptr", unsafe { &*self.ptr.as_ref().value.get() })
             .finish()
+    }
+}
+
+impl<'gc, T: 'gc + Collect + Display> Display for Gc<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", unsafe { &*self.ptr.as_ref().value.get() })
     }
 }
 

--- a/src/bin/compiler.rs
+++ b/src/bin/compiler.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<StdError>> {
     let mut lua = Lua::new();
     lua.mutate(|mc, root| -> Result<(), StaticError> {
         let function = compile(mc, root.interned_strings, file).map_err(|e| e.to_static())?;
-        println!("output: {:#?}", function);
+        println!("{}", function);
         Ok(())
     })?;
 

--- a/src/bin/luster.rs
+++ b/src/bin/luster.rs
@@ -134,7 +134,6 @@ fn main() -> Result<(), Box<StdError>> {
         return Ok(());
     }
 
-    let file = io::buffered_read(File::open(matches.value_of("file").unwrap())?)?;
     lua.sequence(|root| {
         sequence::from_fn_with(root, |mc, root| {
             Ok(Closure::new(

--- a/src/bin/luster.rs
+++ b/src/bin/luster.rs
@@ -102,6 +102,12 @@ fn main() -> Result<(), Box<StdError>> {
                 .long("repl")
                 .help("Load into REPL after loading file, if any"),
         )
+        .arg(
+            Arg::with_name("dump")
+                .short("d")
+                .long("dump")
+                .help("Dump bytecode"),
+        )
         .arg(Arg::with_name("file").help("File to interpret").index(1))
         .get_matches();
 
@@ -114,6 +120,21 @@ fn main() -> Result<(), Box<StdError>> {
 
     let file = io::buffered_read(File::open(matches.value_of("file").unwrap())?)?;
 
+    if matches.is_present("dump") {
+        lua.sequence(|root| {
+            sequence::from_fn_with(root, |mc, root| {
+                let proto = compile(mc, root.interned_strings, file)?;
+                println!("{}", proto);
+                Ok(())
+            })
+            .map_ok(|_| ())
+            .map_err(|e: Error| e.to_static())
+            .boxed()
+        })?;
+        return Ok(());
+    }
+
+    let file = io::buffered_read(File::open(matches.value_of("file").unwrap())?)?;
     lua.sequence(|root| {
         sequence::from_fn_with(root, |mc, root| {
             Ok(Closure::new(

--- a/src/bin/luster.rs
+++ b/src/bin/luster.rs
@@ -106,6 +106,7 @@ fn main() -> Result<(), Box<StdError>> {
             Arg::with_name("dump")
                 .short("d")
                 .long("dump")
+                .conflicts_with("repl")
                 .help("Dump bytecode"),
         )
         .arg(Arg::with_name("file").help("File to interpret").index(1))

--- a/src/bin/luster.rs
+++ b/src/bin/luster.rs
@@ -102,13 +102,6 @@ fn main() -> Result<(), Box<StdError>> {
                 .long("repl")
                 .help("Load into REPL after loading file, if any"),
         )
-        .arg(
-            Arg::with_name("dump")
-                .short("d")
-                .long("dump")
-                .conflicts_with("repl")
-                .help("Dump bytecode"),
-        )
         .arg(Arg::with_name("file").help("File to interpret").index(1))
         .get_matches();
 
@@ -120,20 +113,6 @@ fn main() -> Result<(), Box<StdError>> {
     }
 
     let file = io::buffered_read(File::open(matches.value_of("file").unwrap())?)?;
-
-    if matches.is_present("dump") {
-        lua.sequence(|root| {
-            sequence::from_fn_with(root, |mc, root| {
-                let proto = compile(mc, root.interned_strings, file)?;
-                println!("{}", proto);
-                Ok(())
-            })
-            .map_ok(|_| ())
-            .map_err(|e: Error| e.to_static())
-            .boxed()
-        })?;
-        return Ok(());
-    }
 
     lua.sequence(|root| {
         sequence::from_fn_with(root, |mc, root| {

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -26,6 +26,45 @@ pub struct FunctionProto<'gc> {
     pub prototypes: Vec<Gc<'gc, FunctionProto<'gc>>>,
 }
 
+// Pretty-print a `FunctionProto` with minimal formatting
+impl<'gc> fmt::Display for FunctionProto<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "=============")?;
+        writeln!(f, "FunctionProto({:p})", self)?;
+        writeln!(f, "=============")?;
+        writeln!(
+            f,
+            "fixed_params: {}, has_varargs: {}, stack_size: {}",
+            self.fixed_params, self.has_varargs, self.stack_size
+        )?;
+        if self.constants.len() > 0 {
+            writeln!(f, "constants:")?;
+            for (i, c) in self.constants.iter().enumerate() {
+                writeln!(f, "{}: {:?}", i, c)?;
+            }
+        }
+        if self.opcodes.len() > 0 {
+            writeln!(f, "opcodes:")?;
+            for (i, c) in self.opcodes.iter().enumerate() {
+                writeln!(f, "{}: {:?}", i, c)?;
+            }
+        }
+        if self.upvalues.len() > 0 {
+            writeln!(f, "upvalues:")?;
+            for (i, u) in self.upvalues.iter().enumerate() {
+                writeln!(f, "{}: {:?}", i, u)?;
+            }
+        }
+        if self.prototypes.len() > 0 {
+            writeln!(f, "prototypes:")?;
+            for p in self.prototypes.iter() {
+                writeln!(f, "{}", p)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Collect, Copy, Clone)]
 #[collect(require_copy)]
 pub enum UpValueState<'gc> {


### PR DESCRIPTION
First of all, thanks for the amazing project! I learned a lot from it. :)

This PR added a new command line flag `--dump`(`-d`). When provided, luster will print the parsed bytecode without actually running the code. I find it pretty useful for understanding the internal. It might also be helpful for others.

For now, I just dump the `FunctionProto` with `Debug` trait with minimal formatting. It's definitely note a good textual representation of luster's bytecode. However, it's fine for learning purpose IMO.

Example:

```lua
-- test.lua
local x = 1

function foo(y)
    return x + y
end

print(foo(2))
```

```
$ luster --dump test.lua
=============
FunctionProto(0x7ffee596b9d0)
=============
fixed_params: 0, has_varargs: true, stack_size: 4
constants:
0: Integer(1)
1: String(Short8(3, Gc { ptr: [102, 111, 111, 0, 0, 0, 0, 0] }))
2: String(Short8(5, Gc { ptr: [112, 114, 105, 110, 116, 0, 0, 0] }))
3: Integer(2)
opcodes:
0: LoadConstant { dest: RegisterIndex(0), constant: ConstantIndex16(0) }
1: Closure { dest: RegisterIndex(1), proto: PrototypeIndex(0) }
2: SetUpTableCR { table: UpValueIndex(0), key: ConstantIndex8(1), value: RegisterIndex(1) }
3: GetUpTableC { dest: RegisterIndex(1), table: UpValueIndex(0), key: ConstantIndex8(2) }
4: GetUpTableC { dest: RegisterIndex(2), table: UpValueIndex(0), key: ConstantIndex8(1) }
5: LoadConstant { dest: RegisterIndex(3), constant: ConstantIndex16(3) }
6: Call { func: RegisterIndex(2), args: VarCount(Opt254(Some(1))), returns: VarCount(Opt254(None)) }
7: Call { func: RegisterIndex(1), args: VarCount(Opt254(None)), returns: VarCount(Opt254(Some(0))) }
8: Jump { offset: 0, close_upvalues: Opt254(Some(0)) }
9: Return { start: RegisterIndex(0), count: VarCount(Opt254(Some(0))) }
upvalues:
0: Environment
prototypes:
=============
FunctionProto(0x7ff69bc06be8)
=============
fixed_params: 1, has_varargs: false, stack_size: 2
opcodes:
0: GetUpValue { dest: RegisterIndex(1), source: UpValueIndex(0) }
1: AddRR { dest: RegisterIndex(1), left: RegisterIndex(1), right: RegisterIndex(0) }
2: Return { start: RegisterIndex(1), count: VarCount(Opt254(Some(1))) }
3: Return { start: RegisterIndex(0), count: VarCount(Opt254(Some(0))) }
upvalues:
0: ParentLocal(RegisterIndex(0))
``
