### PR TITLE
Partially add `string` methods

### DIFF
--- a/src/lua.rs
+++ b/src/lua.rs
@@ -2,7 +2,7 @@ use gc_arena::{ArenaParameters, Collect, MutationContext};
 use gc_sequence::{make_sequencable_arena, Sequence};
 
 use crate::{
-    stdlib::{load_base, load_coroutine, load_math},
+    stdlib::{load_base, load_coroutine, load_math, load_string},
     InternedStringSet, Table, Thread,
 };
 
@@ -25,6 +25,7 @@ impl<'gc> Root<'gc> {
         load_base(mc, root, root.globals);
         load_coroutine(mc, root, root.globals);
         load_math(mc, root, root.globals);
+        load_string(mc, root, root.globals);
 
         root
     }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,7 +1,9 @@
 mod base;
 mod coroutine;
 mod math;
+mod string;
 
 pub use base::load_base;
 pub use coroutine::load_coroutine;
 pub use math::load_math;
+pub use string::load_string;

--- a/src/stdlib/string.rs
+++ b/src/stdlib/string.rs
@@ -1,0 +1,85 @@
+use gc_arena::MutationContext;
+
+use crate::{Callback, CallbackResult, Root, RuntimeError, String, Table, Value};
+
+pub fn load_string<'gc>(mc: MutationContext<'gc, '_>, _: Root<'gc>, env: Table<'gc>) {
+    let string = Table::new(mc);
+
+    string
+        .set(
+            mc,
+            String::new_static(b"len"),
+            Callback::new_immediate(mc, |args| {
+                let s = args.get(0).cloned().unwrap_or(Value::Nil);
+
+                if let Value::String(s) = s {
+                    let len = Value::Integer(s.len() as i64);
+                    Ok(CallbackResult::Return(vec![len]))
+                } else {
+                    Err(RuntimeError(Value::String(String::new_static(
+                        b"Argument must be a string.",
+                    )))
+                    .into())
+                }
+            }),
+        )
+        .unwrap();
+
+    string
+        .set(
+            mc,
+            String::new_static(b"byte"),
+            Callback::new_immediate(mc, |args| {
+                let s = match args.get(0).cloned().unwrap_or(Value::Nil) {
+                    Value::String(s) => s,
+                    _ => {
+                        return Err(RuntimeError(Value::String(String::new_static(
+                            b"Target must be a string.",
+                        )))
+                        .into());
+                    }
+                };
+                let i = match args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or(Value::Integer(1))
+                    .to_integer()
+                {
+                    Some(i) => i,
+                    None => {
+                        return Err(RuntimeError(Value::String(String::new_static(
+                            b"Start index must be a number.",
+                        )))
+                        .into());
+                    }
+                };
+                let j = match args
+                    .get(2)
+                    .cloned()
+                    .unwrap_or(Value::Integer(i))
+                    .to_integer()
+                {
+                    Some(j) => j,
+                    None => {
+                        return Err(RuntimeError(Value::String(String::new_static(
+                            b"End index must be a number.",
+                        )))
+                        .into());
+                    }
+                };
+
+                Ok(CallbackResult::Return(
+                    match s.as_bytes().get(((i - 1) as usize)..=((j - 1) as usize)) {
+                        Some(bytes) => bytes
+                            .into_iter()
+                            .map(|b| Value::Integer(*b as i64))
+                            .collect::<Vec<_>>(),
+                        None => vec![Value::Nil],
+                    },
+                ))
+            }),
+        )
+        .unwrap();
+
+    env.set(mc, String::new_static(b"string"), string).unwrap();
+}


### PR DESCRIPTION
I have only added two functions -- `len` and `byte`.

**Addition:**
When I was trying adding more functions *(not the `len` and `byte` function in this PR)*, I have encountered some issues about lifetime when using `String::new`, possibly due to my limitation of Rust knowledge.

<pre>[<font color="#8AE234"><b>0</b></font>] % <font color="#4E9A06">cargo</font> check
<font color="#8AE234"><b>    Checking</b></font> luster v0.1.0 (/mnt/working/Programming/Rust/luster)
<font color="#EF2929"><b>error[E0477]</b></font><b>: the type `[closure@src/stdlib/string.rs:12:41: 26:14 mc:&amp;gc_arena::context::MutationContext&lt;&apos;gc, &apos;_&gt;]` does not fulfill the required lifetime</b>
  <font color="#729FCF"><b>--&gt; </b></font>src/stdlib/string.rs:12:13
   <font color="#729FCF"><b>|</b></font>
<font color="#729FCF"><b>12</b></font> <font color="#729FCF"><b>| </b></font>            Callback::new_immediate(mc, |args| {
   <font color="#729FCF"><b>| </b></font>            <font color="#EF2929"><b>^^^^^^^^^^^^^^^^^^^^^^^</b></font>
   <font color="#729FCF"><b>|</b></font>
   <font color="#729FCF"><b>= </b></font><b>note</b>: type must satisfy the static lifetime

<font color="#EF2929"><b>error[E0621]</b></font><b>: explicit lifetime required in the type of `mc`</b>
  <font color="#729FCF"><b>--&gt; </b></font>src/stdlib/string.rs:12:13
   <font color="#729FCF"><b>|</b></font>
<font color="#729FCF"><b>5</b></font>  <font color="#729FCF"><b>| </b></font>pub fn load_string&lt;&apos;gc&gt;(mc: MutationContext&lt;&apos;gc, &apos;_&gt;, _: Root&lt;&apos;gc&gt;, env: Table&lt;&apos;gc&gt;) {
   <font color="#729FCF"><b>| </b></font>                            <font color="#729FCF"><b>------------------------</b></font> <font color="#729FCF"><b>help: add explicit lifetime `&apos;static` to the type of `mc`: `gc_arena::context::MutationContext&lt;&apos;gc, &apos;static&gt;`</b></font>
<font color="#729FCF"><b>...</b></font>
<font color="#729FCF"><b>12</b></font> <font color="#729FCF"><b>| </b></font>            Callback::new_immediate(mc, |args| {
   <font color="#729FCF"><b>| </b></font>            <font color="#EF2929"><b>^^^^^^^^^^^^^^^^^^^^^^^</b></font> <font color="#EF2929"><b>lifetime `&apos;static` required</b></font>

<font color="#EF2929"><b>error</b></font><b>: aborting due to 2 previous errors</b>

<b>Some errors occurred: E0477, E0621.</b>
<b>For more information about an error, try `rustc --explain E0477`.</b>
<font color="#EF2929"><b>error:</b></font> Could not compile `luster`.

To learn more, run the command again with --verbose.
</pre>