### PR TITLE
Add string.{char, lower, upper, reverse} to stdlib

### DIFF
--- a/src/stdlib/string.rs
+++ b/src/stdlib/string.rs
@@ -12,15 +12,98 @@ pub fn load_string<'gc>(mc: MutationContext<'gc, '_>, _: Root<'gc>, env: Table<'
             String::new_static(b"len"),
             Callback::new_sequence(mc, |args| {
                 Ok(sequence::from_fn_with(args, |mc, args| {
-                    match args
-                        .get(0)
-                        .cloned()
-                        .unwrap_or(Value::Nil)
-                        .to_string(mc)
-                    {
+                    match args.get(0).cloned().unwrap_or(Value::Nil).to_string(mc) {
                         Some(s) => Ok(CallbackResult::Return(vec![Value::Integer(s.len())])),
                         None => Err(RuntimeError(Value::String(String::new_static(
                             b"Bad argument to len",
+                        )))
+                        .into()),
+                    }
+                }))
+            }),
+        )
+        .unwrap();
+
+    string
+        .set(
+            mc,
+            String::new_static(b"char"),
+            Callback::new_sequence(mc, |args| {
+                Ok(sequence::from_fn_with(args, |mc, args| {
+                    args.iter()
+                        .try_fold(Vec::with_capacity(args.len()), |mut bytes, arg| {
+                            match arg.to_integer() {
+                                Some(i) => {
+                                    if i >= 0 && i <= 255 {
+                                        bytes.push(i as u8);
+                                        Ok(bytes)
+                                    } else {
+                                        Err(RuntimeError(Value::String(String::new_static(
+                                            b"Bad argument to char (value out of range)",
+                                        )))
+                                        .into())
+                                    }
+                                }
+                                None => Err(RuntimeError(Value::String(String::new_static(
+                                    b"Bad argument to char",
+                                )))
+                                .into()),
+                            }
+                        })
+                        .map(|bytes| {
+                            CallbackResult::Return(vec![Value::String(String::new(mc, &bytes))])
+                        })
+                }))
+            }),
+        )
+        .unwrap();
+
+    string
+        .set(
+            mc,
+            String::new_static(b"upper"),
+            Callback::new_sequence(mc, |args| {
+                Ok(sequence::from_fn_with(args, |mc, args| {
+                    match args.get(0).cloned().unwrap_or(Value::Nil).to_string(mc) {
+                        Some(s) => Ok(CallbackResult::Return(vec![Value::String(s.upper(mc))])),
+                        None => Err(RuntimeError(Value::String(String::new_static(
+                            b"Bad argument to upper",
+                        )))
+                        .into()),
+                    }
+                }))
+            }),
+        )
+        .unwrap();
+
+    string
+        .set(
+            mc,
+            String::new_static(b"lower"),
+            Callback::new_sequence(mc, |args| {
+                Ok(sequence::from_fn_with(args, |mc, args| {
+                    match args.get(0).cloned().unwrap_or(Value::Nil).to_string(mc) {
+                        Some(s) => Ok(CallbackResult::Return(vec![Value::String(s.lower(mc))])),
+                        None => Err(RuntimeError(Value::String(String::new_static(
+                            b"Bad argument to lower",
+                        )))
+                        .into()),
+                    }
+                }))
+            }),
+        )
+        .unwrap();
+
+    string
+        .set(
+            mc,
+            String::new_static(b"reverse"),
+            Callback::new_sequence(mc, |args| {
+                Ok(sequence::from_fn_with(args, |mc, args| {
+                    match args.get(0).cloned().unwrap_or(Value::Nil).to_string(mc) {
+                        Some(s) => Ok(CallbackResult::Return(vec![Value::String(s.reverse(mc))])),
+                        None => Err(RuntimeError(Value::String(String::new_static(
+                            b"Bad argument to reverse",
                         )))
                         .into()),
                     }

--- a/tests/running/string.lua
+++ b/tests/running/string.lua
@@ -9,7 +9,7 @@ function test_concat()
         1 .. 2 .. 3 == "123"
 end
 
-function test_coroutine_len()
+function test_coroutine()
     return nil
 end
 
@@ -20,7 +20,7 @@ function test_len()
         is_err(function() return string.len(false) end) and
         is_err(function() return string.len({}) end) and
         is_err(function() return string.len(is_err) end) and
-        is_err(function() return string.len(coroutine.create(test_coroutine_len)) end) and
+        is_err(function() return string.len(coroutine.create(test_coroutine)) end) and
         string.len("") == 0 and
         string.len("x") == 1 and
         string.len("x\0") == 2 and
@@ -35,5 +35,90 @@ function test_len()
         string.len(-2147483648) == 11
 end
 
+function test_char()
+    for i = 0,255,1
+    do
+        if is_err(function() return string.char(i) end) or string.len(string.char(i)) ~= 1 then
+	    return false
+        end
+    end
+    return
+        is_err(function() return string.char(-1) end) and
+        is_err(function() return string.char(256) end) and
+        is_err(function() return string.char(1.5) end) and
+        is_err(function() return string.char(nil) end) and
+        is_err(function() return string.char(true) end) and
+        is_err(function() return string.char(false) end) and
+        is_err(function() return string.char({}) end) and
+        is_err(function() return string.char(is_err) end) and
+        is_err(function() return string.char(coroutine.create(test_coroutine)) end) and
+        string.char() == "" and
+        string.char(65.0) == "A" and
+        string.char("65") == "A" and
+        string.char(65) == "A" and
+        string.char(65, 66) == "AB" and
+        string.char(65, 66, 67) == "ABC" and
+        string.char(0) == "\0"
+end
+
+function test_lower()
+    for i = 0,255,1
+    do
+        if i >= 65 and i <= 90 then
+            if string.lower(string.char(i)) ~= string.char(i + 32) then return false end
+        else
+            if string.lower(string.char(i)) ~= string.char(i) then return false end
+        end
+    end
+    return
+        is_err(function() return string.lower(nil) end) and
+        is_err(function() return string.lower(true) end) and
+        is_err(function() return string.lower(false) end) and
+        is_err(function() return string.lower({}) end) and
+        is_err(function() return string.lower(is_err) end) and
+        is_err(function() return string.lower(coroutine.create(test_coroutine)) end) and
+        string.lower("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") == "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" -- > 32 bytes
+end
+
+function test_upper()
+    for i = 0,255,1
+    do
+        if i >= 97 and i <= 122 then
+            if string.upper(string.char(i)) ~= string.char(i - 32) then return false end
+        else
+            if string.upper(string.char(i)) ~= string.char(i) then return false end
+        end
+    end
+    return
+        is_err(function() return string.upper(nil) end) and
+        is_err(function() return string.upper(true) end) and
+        is_err(function() return string.upper(false) end) and
+        is_err(function() return string.upper({}) end) and
+        is_err(function() return string.upper(is_err) end) and
+        is_err(function() return string.upper(coroutine.create(test_coroutine)) end) and
+        string.upper("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ" and -- > 32 bytes
+        string.upper("") == ""
+end
+
+function test_reverse()
+    return
+        is_err(function() return string.reverse(nil) end) and
+        is_err(function() return string.reverse(true) end) and
+        is_err(function() return string.reverse(false) end) and
+        is_err(function() return string.reverse({}) end) and
+        is_err(function() return string.reverse(is_err) end) and
+        is_err(function() return string.reverse(coroutine.create(test_coroutine)) end) and
+        string.reverse("") == "" and
+        string.reverse("A") == "A" and
+        string.reverse("AB") == "BA" and
+        string.reverse("0123456789012345678901234567890123456789") == "9876543210987654321098765432109876543210" and -- > 32 bytes
+        string.reverse(1.2) == "2.1" and
+        string.reverse(12) == "21"
+end
+
 return test_concat() and
-       test_len()
+       test_len() and
+       test_char() and
+       test_lower() and
+       test_upper() and
+       test_reverse()


### PR DESCRIPTION
I believe that a "sufficiently smart compiler" would compile this String::new to the same machine code as the existing implementation. (Pretty sure rustc isn't that compiler, though.)

Could retain the existing implementation for performance.